### PR TITLE
Migrates from goodtables.io to Frictionless Repostory

### DIFF
--- a/.github/frictionless.yaml
+++ b/.github/frictionless.yaml
@@ -1,0 +1,8 @@
+main:
+  tasks:
+    - source: data/valid/datapackage.json
+      type: package
+    - source: data/auxiliary/geographic/datapackage.json
+      type: package
+    - source: data/archive/datapackage.json
+      type: package

--- a/.github/workflows/frictionless.yaml
+++ b/.github/workflows/frictionless.yaml
@@ -1,0 +1,18 @@
+name: frictionless-repository
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Validate data
+        uses: frictionlessdata/repository@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-.*
+# local VSCode config
+.vscode
+
 # python virtual environments
 pyenv
 env

--- a/goodtables.yml
+++ b/goodtables.yml
@@ -1,5 +1,0 @@
-datapackages:
-    - data/valid/datapackage.json
-    - data/auxiliary/geographic/datapackage.json
-    - data/archive/datapackage.json
-


### PR DESCRIPTION
This will fix #27.

Goodtables.io is to be deactivated so for the data validation to continue we need to move to [Frictionless Repository](https://repository.frictionlessdata.io/).