### PR TITLE
Adds primary keys to data validation

### DIFF
--- a/data/valid/datapackage.json
+++ b/data/valid/datapackage.json
@@ -107,6 +107,7 @@
             "description": "Last time the site was manually verified to be in working order"
           }
         ],
+        "primaryKey": ["state_code", "municipality_code", "sphere", "branch"],
         "missingValues": [
           ""
         ]
@@ -209,6 +210,7 @@
             "description": "Last time the site was manually verified to be in working order"
           }
         ],
+        "primaryKey": ["state_code", "municipality_code", "sphere", "branch", "notes"],
         "missingValues": [
           ""
         ]


### PR DESCRIPTION
closes #160

Tests will fail because there is duplicated data. This should be fixed separately (#161).